### PR TITLE
trusty: change the key of simulated RPMB

### DIFF
--- a/hwcrypto/platform/solutions/provider_dummy.c
+++ b/hwcrypto/platform/solutions/provider_dummy.c
@@ -150,7 +150,7 @@ uint32_t get_rpmb_ss_auth_key(const struct hwkey_keyslot *slot,
 {
 	assert(kbuf && klen);
 
-	memcpy_s(kbuf, RPMB_SS_AUTH_KEY_SIZE, "12345ABCDEF1234512345ABCDEF12345", RPMB_SS_AUTH_KEY_SIZE);
+	memcpy_s(kbuf, RPMB_SS_AUTH_KEY_SIZE, "11111111111111111111111111111111", RPMB_SS_AUTH_KEY_SIZE);
 	*klen = RPMB_SS_AUTH_KEY_SIZE;
 	return 0;
 }


### PR DESCRIPTION
Kernelflinger changed the key to 32 "1".

Change-Id: I76e90bfcc69d6f5ff648b25177be826fe072da0e
Signed-off-by: Cliff Cai cliff.cai@intel.com